### PR TITLE
[RFR] Adds release id and totalPages to returned results

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ var marketplace = require('discogs-marketplace-js');
 
 ####Search By ID
 
+*Note*: Prefix the release ID with one of the following:
+
+- `m` for Master Release
+- `r` for Release
+- `l` for Label
+
 ````javascript
 marketplace.searchByID('m1234', function(result){
 	if(!(result instanceof Error))
@@ -35,7 +41,7 @@ To specify search filters and pagination options, discogs-marketplace-js will ac
 ````javascript
 var search_parameters = {
 	id: "1067610", //id can also be a string
-	type: "release",
+	type: "release", //one of: 'release', 'master', 'label'
 	filters: {
 		genre: "Rock",
 		style: null,

--- a/lib/search.js
+++ b/lib/search.js
@@ -30,7 +30,7 @@ marketplace.searchByID = function(params, callback){
 			type = "label";
 		else
 			return callback(new Error("Invalid id."));
-		id = id.substr(1);
+		
 		if(isNaN(id))
 			return callback(new Error("Invalid id."));
 	}

--- a/lib/search.js
+++ b/lib/search.js
@@ -36,8 +36,8 @@ marketplace.searchByID = function(params, callback){
 	}
 	else
 		return callback(new Error("Invalid parameters"));
-	var path = util.buildPath(id,type,filters,pagination);
-	util.generateResult(path, callback);
+	var path = util.buildPath(id, type, filters, pagination);
+	util.generateResult(path, id, callback);
 }
 
 //params can be object or string literal
@@ -55,5 +55,5 @@ marketplace.searchByString = function(params, callback){
 	else
 		return callback(new Error("Invalid parameters"));
 	var path = util.buildPath(id, "string", filters, pagination);
-	util.generateResult(path, callback);
+	util.generateResult(path, id, callback);
 }

--- a/lib/search.js
+++ b/lib/search.js
@@ -37,7 +37,7 @@ marketplace.searchByID = function(params, callback){
 	else
 		return callback(new Error("Invalid parameters"));
 	var path = util.buildPath(id, type, filters, pagination);
-	util.generateResult(path, id, callback);
+	util.generateResult(path, params, callback);
 }
 
 //params can be object or string literal
@@ -55,5 +55,5 @@ marketplace.searchByString = function(params, callback){
 	else
 		return callback(new Error("Invalid parameters"));
 	var path = util.buildPath(id, "string", filters, pagination);
-	util.generateResult(path, id, callback);
+	util.generateResult(path, params, callback);
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -45,13 +45,13 @@ util.processPaginationResponse = function(obj, params){
 	var $ = cheerio.load(obj);
 	var result = new Object();
 	var tempString = $(".pagination_total").text().split("of")[1].trim();
-	var totalItems = parseFloat(tempString.replace(',',""));
+	var totalItems = parseFloat(tempString.replace(',',"")) || 0;
 	var perPage = typeof params === 'object'
 		? (params.pagination && params.pagination.per_page) || 50
 		: 50;
 	result.items = totalItems;
 	result.hasNext = $(".pagination_next").is("a");
-	result.totalPages = Math.ceil((totalItems / perPage)) || 0;
+	result.totalPages = Math.ceil((totalItems / perPage));
 	return result;
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -10,7 +10,7 @@ var request = require('request');
 var util = module.exports = {};
 
 
-util.processBody = function(body){
+util.processBody = function(body, id){
 	var result = new Object();
 	var pagination = new Object();
 	var listing = new Array();
@@ -23,6 +23,7 @@ util.processBody = function(body){
 	});
 	result.pagination = pagination;
 	result.listing = listing;
+	result.id = id;
 	return result;
 }
 
@@ -47,7 +48,7 @@ util.processPaginationResponse = function(obj){
 	return result;
 }
 
-util.generateResult = function(path, callback){
+util.generateResult = function(path, id, callback){
 	var options = {
 		url: path,
 		headers: {
@@ -59,7 +60,7 @@ util.generateResult = function(path, callback){
 		var result;
 		if(error)
 			result = error;
-		result = util.processBody(body);
+		result = util.processBody(body, id);
 		callback(result);
 	}
 	request(options,call_result);
@@ -93,7 +94,7 @@ util.processFilters = function(filters){
 	return filterString.join('&');
 }
 
-util.handleFilterProperty = function(key,value){
+util.handleFilterProperty = function(key, value){
 	var tag;
 	if(Array.isArray(value)){
 		tag = [];

--- a/lib/util.js
+++ b/lib/util.js
@@ -16,14 +16,16 @@ util.processBody = function(body, params){
 	var listing = new Array();
 	var $ = cheerio.load(body);
 	var paginationBody = $(".pagination.bottom").get();
-	pagination = util.processPaginationResponse(paginationBody);
+	pagination = util.processPaginationResponse(paginationBody, params);
 	$(".shortcut_navigable").each(function(i, obj){
 		var item = util.processItem(obj);
 		listing.push(item);
 	});
 	result.pagination = pagination;
 	result.listing = listing;
-	result.id = typeof params === "object" ? params.id : params.substr(1);
+	result.id = typeof params === "object"
+		? params.id
+		: params.replace(/^(m|r|l)/, "");
 	return result;
 }
 
@@ -39,12 +41,17 @@ util.processItem = function(obj){
 	return item;
 }
 
-util.processPaginationResponse = function(obj){
+util.processPaginationResponse = function(obj, params){
 	var $ = cheerio.load(obj);
 	var result = new Object();
 	var tempString = $(".pagination_total").text().split("of")[1].trim();
-	result.items = parseFloat(tempString.replace(',',""));
+	var totalItems = parseFloat(tempString.replace(',',""));
+	var perPage = typeof params === 'object'
+		? (params.pagination && params.pagination.per_page) || 50
+		: 50;
+	result.items = totalItems;
 	result.hasNext = $(".pagination_next").is("a");
+	result.totalPages = Math.ceil((totalItems / perPage)) || 1;
 	return result;
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -10,7 +10,7 @@ var request = require('request');
 var util = module.exports = {};
 
 
-util.processBody = function(body, id){
+util.processBody = function(body, params){
 	var result = new Object();
 	var pagination = new Object();
 	var listing = new Array();
@@ -23,7 +23,7 @@ util.processBody = function(body, id){
 	});
 	result.pagination = pagination;
 	result.listing = listing;
-	result.id = id;
+	result.id = typeof params === 'object' ? params.id : params.substr(1);
 	return result;
 }
 
@@ -48,7 +48,7 @@ util.processPaginationResponse = function(obj){
 	return result;
 }
 
-util.generateResult = function(path, id, callback){
+util.generateResult = function(path, params, callback){
 	var options = {
 		url: path,
 		headers: {
@@ -60,7 +60,7 @@ util.generateResult = function(path, id, callback){
 		var result;
 		if(error)
 			result = error;
-		result = util.processBody(body, id);
+		result = util.processBody(body, params);
 		callback(result);
 	}
 	request(options,call_result);

--- a/lib/util.js
+++ b/lib/util.js
@@ -23,7 +23,7 @@ util.processBody = function(body, params){
 	});
 	result.pagination = pagination;
 	result.listing = listing;
-	result.id = typeof params === 'object' ? params.id : params.substr(1);
+	result.id = typeof params === "object" ? params.id : params.substr(1);
 	return result;
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -51,7 +51,7 @@ util.processPaginationResponse = function(obj, params){
 		: 50;
 	result.items = totalItems;
 	result.hasNext = $(".pagination_next").is("a");
-	result.totalPages = Math.ceil((totalItems / perPage)) || 1;
+	result.totalPages = Math.ceil((totalItems / perPage)) || 0;
 	return result;
 }
 


### PR DESCRIPTION
Saw the TODO list on the repo so thought I would add a PR for the first item.
May use this script myself in the near future - thanks for creating it! 

If I understood correctly the ID from the params needs to be returned on the result so I just added it at the root of the object, checking for (and if so, removing) string prefixes that start with `m`, `l`, or `r`.

I also added the `totalPages` calculation. The results object now has this shape:

```
{
  pagination: {
    items: 0,
    hasNext: false,
    totalPages: 0
  },
  listing: [],
  id: '1067610'
}
```