### PR TITLE
Adding release link per item

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -37,6 +37,7 @@ util.processItem = function(obj){
 	item.seller = $(".seller_info a").eq(0).text();
 	item.ships_from = $(".seller_info li").eq(2).text().replace("Ships From:","");
 	item.price = $(".price").eq(0).text();
+	item.release_link = $(".item_release_link").eq(0).attr('href');
 	return item;
 }
 


### PR DESCRIPTION
Small change - found it useful to be able to use the release link from searching as it contains the release ID.
I was tempted to return just the ID by splitting the url up but I think that's best done by whoever uses the library.